### PR TITLE
Make ZLSwipeableViewDirection public

### DIFF
--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -33,14 +33,14 @@ public struct ZLSwipeableViewDirection : RawOptionSetType, Printable {
         return self(rawValue: 0)
     }
 
-    static var None: ZLSwipeableViewDirection       { return self(rawValue: 0b0000) }
-    static var Left: ZLSwipeableViewDirection       { return self(rawValue: 0b0001) }
-    static var Right: ZLSwipeableViewDirection      { return self(rawValue: 0b0010) }
-    static var Up: ZLSwipeableViewDirection         { return self(rawValue: 0b0100) }
-    static var Down: ZLSwipeableViewDirection       { return self(rawValue: 0b1000) }
-    static var Horizontal: ZLSwipeableViewDirection { return Left | Right }
-    static var Vertical: ZLSwipeableViewDirection   { return Up | Down }
-    static var All: ZLSwipeableViewDirection        { return Horizontal | Vertical }
+    public static var None: ZLSwipeableViewDirection       { return self(rawValue: 0b0000) }
+    public static var Left: ZLSwipeableViewDirection       { return self(rawValue: 0b0001) }
+    public static var Right: ZLSwipeableViewDirection      { return self(rawValue: 0b0010) }
+    public static var Up: ZLSwipeableViewDirection         { return self(rawValue: 0b0100) }
+    public static var Down: ZLSwipeableViewDirection       { return self(rawValue: 0b1000) }
+    public static var Horizontal: ZLSwipeableViewDirection { return Left | Right }
+    public static var Vertical: ZLSwipeableViewDirection   { return Up | Down }
+    public static var All: ZLSwipeableViewDirection        { return Horizontal | Vertical }
     
     static func fromPoint(point: CGPoint) -> ZLSwipeableViewDirection {
         switch (point.x, point.y) {


### PR DESCRIPTION
ZLSwipeableViewDirection has to be public so that it can be used in swipeableView.swipeTopView(inDirection: )
