### PR TITLE
Remove Retain Cycle

### DIFF
--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -651,6 +651,8 @@ internal class Scheduler : NSObject {
         guard let action = action, let endCondition = endCondition where !endCondition() else {
             timer.invalidate()
             self.timer = nil
+            self.action = nil
+            self.endCondition = nil
             return
         }
         action()


### PR DESCRIPTION
To prevent a retain cycle created by NSTimer.  We need to set action and endCondition to nil.
