### PR TITLE
Fix rewind's edge cases and incorrect removal.

### DIFF
--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -147,8 +147,8 @@ public class ZLSwipeableView: UIView {
 
         guard let view = viewToBeRewinded else { return }
 
-        if UInt(allViews().count) == numberOfActiveView && allViews().first != nil {
-            remove(allViews().first!)
+        if UInt(activeViews().count) == numberOfActiveView && activeViews().first != nil {
+            remove(activeViews().last!)
         }
         insert(view, atIndex: allViews().count)
         updateViews()

--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -147,7 +147,9 @@ public class ZLSwipeableView: UIView {
 
         guard let view = viewToBeRewinded else { return }
 
-        remove(activeViews().last!)
+        if UInt(allViews().count) == numberOfActiveView && allViews().last != nil {
+            remove(allViews().first!)
+        }
         insert(view, atIndex: allViews().count)
         updateViews()
     }

--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -147,7 +147,7 @@ public class ZLSwipeableView: UIView {
 
         guard let view = viewToBeRewinded else { return }
 
-        if UInt(allViews().count) == numberOfActiveView && allViews().last != nil {
+        if UInt(allViews().count) == numberOfActiveView && allViews().first != nil {
             remove(allViews().first!)
         }
         insert(view, atIndex: allViews().count)


### PR DESCRIPTION
Rewind used to remove the view on top of the stack before inserting the rewinding view on top of the stack.  It now removes the view at the back of the stack instead.  This ensures correct continuity of your items.  

Also, during cases were there was only one card, this method would unwrap a nil value from activeViews().last.  It now makes sure that there is a view to remove and that it should remove it to stay within the bounds of the number of active views allowed.
