### PR TITLE
Only add tap recognizer if user has a custom tap handler

### DIFF
--- a/ZLSwipeableViewSwift/ViewManager.swift
+++ b/ZLSwipeableViewSwift/ViewManager.swift
@@ -69,7 +69,9 @@ class ViewManager : NSObject {
         super.init()
         
         view.addGestureRecognizer(ZLPanGestureRecognizer(target: self, action: #selector(ViewManager.handlePan(_:))))
-        view.addGestureRecognizer(ZLTapGestureRecognizer(target: self, action: #selector(ViewManager.handleTap(_:))))
+        if swipeableView.didTap != nil {
+            view.addGestureRecognizer(ZLTapGestureRecognizer(target: self, action: #selector(ViewManager.handleTap(_:))))
+        }
         miscContainerView.addSubview(anchorView)
         containerView.insertSubview(view, at: index)
     }

--- a/ZLSwipeableViewSwift/ViewManager.swift
+++ b/ZLSwipeableViewSwift/ViewManager.swift
@@ -70,7 +70,7 @@ class ViewManager : NSObject {
         
         view.addGestureRecognizer(ZLPanGestureRecognizer(target: self, action: #selector(ViewManager.handlePan(_:))))
         if swipeableView.didTap != nil {
-            view.addGestureRecognizer(ZLTapGestureRecognizer(target: self, action: #selector(ViewManager.handleTap(_:))))
+            self.addTapRecognizer()
         }
         miscContainerView.addSubview(anchorView)
         containerView.insertSubview(view, at: index)
@@ -140,6 +140,12 @@ class ViewManager : NSObject {
         default:
             break
         }
+    }
+    
+    func addTapRecognizer() {
+        guard !(view.gestureRecognizers ?? []).contains(where: { $0 is ZLTapGestureRecognizer }) else { return }
+
+        view.addGestureRecognizer(ZLTapGestureRecognizer(target: self, action: #selector(ViewManager.handleTap(_:))))
     }
     
     func handleTap(_ recognizer: UITapGestureRecognizer) {

--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -64,6 +64,7 @@ open class ZLSwipeableView: UIView {
     open var didCancel: DidCancelHandler?
     open var didTap: DidTap? {
         didSet {
+            guard didTap != nil else { return }
             // Update all viewManagers to listen for taps
             viewManagers.forEach { view, viewManager in
                 viewManager.addTapRecognizer()

--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -62,7 +62,14 @@ open class ZLSwipeableView: UIView {
     open var didEnd: DidEndHandler?
     open var didSwipe: DidSwipeHandler?
     open var didCancel: DidCancelHandler?
-    open var didTap: DidTap?
+    open var didTap: DidTap? {
+        didSet {
+            // Update all viewManagers to listen for taps
+            viewManagers.forEach { view, viewManager in
+                viewManager.addTapRecognizer()
+            }
+        }
+    }
     open var didDisappear: DidDisappear?
 
     // MARK: Private properties


### PR DESCRIPTION
The current tap gesture recognizer will prevent a `UITableView` from functioning properly because it will never receive the gesture. This change only adds the gesture recognizer if the user has chosen to provide their own handler. 