### PR TITLE
ZLSwipeableView.swift: avoid compiler warning

### DIFF
--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -247,7 +247,7 @@ extension ZLSwipeableView {
 
     static func defaultAnimateViewHandler() -> AnimateViewHandler {
         func toRadian(_ degree: CGFloat) -> CGFloat {
-            return degree * CGFloat(M_PI / 180)
+            return degree * CGFloat(Double.pi / 180)
         }
 
         func rotateView(_ view: UIView, forDegree degree: CGFloat, duration: TimeInterval, offsetFromCenter offset: CGPoint, swipeableView: ZLSwipeableView,  completion: ((Bool) -> Void)? = nil) {


### PR DESCRIPTION
Compiler for Swift 3+ will complain about M_PI usage, as it has been
marked as deprecated.  Use Double.pi to avoid this warning during
compile time.

Signed-off-by: Jamie Couture <jamie.couture@crowdspark.com>