### PR TITLE
Fix subviews position on orientation change, refs #120

### DIFF
--- a/ZLSwipeableViewSwift/ViewManager.swift
+++ b/ZLSwipeableViewSwift/ViewManager.swift
@@ -173,6 +173,13 @@ class ViewManager : NSObject {
         removeBehavior(snapBehavior)
     }
     
+    func resnapView() {
+        if case .snapping(_) = state {
+            unsnapView()
+            state = snappingStateAtContainerCenter()
+        }
+    }
+    
     fileprivate func attachView(toPoint point: CGPoint) {
         anchorView.center = point
         anchorView.backgroundColor = UIColor.blue

--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -117,6 +117,9 @@ open class ZLSwipeableView: UIView {
     override open func layoutSubviews() {
         super.layoutSubviews()
         containerView.frame = bounds
+        for viewManager in viewManagers.values {
+            viewManager.resnapView()
+        }
     }
 
     // MARK: Public APIs


### PR DESCRIPTION
Re-snap subviews to bounds center when it changes (due to screen orientation change for example).

EDIT by @AndrewSB: closes #120 