### PR TITLE
fix: clear history in discardViews()

### DIFF
--- a/ZLSwipeableViewSwift/ZLSwipeableView.swift
+++ b/ZLSwipeableViewSwift/ZLSwipeableView.swift
@@ -176,6 +176,7 @@ open class ZLSwipeableView: UIView {
         for view in allViews() {
             remove(view)
         }
+        history = []
     }
 
     open func swipeTopView(inDirection direction: Direction) {


### PR DESCRIPTION
The `discardViews()` will remove all `subviews` in `containerView`, there will be no need to keep the `history` array for those removed views.
Otherwise, if the `ZLSwipeableView` is reloaded without clearing the `history`, there will be some judgement problem in `nextCardView()` during the usage of history.