### PR TITLE
Update ZLSwipeableViewSwift.podspec for 0.0.9

### DIFF
--- a/ZLSwipeableViewSwift.podspec
+++ b/ZLSwipeableViewSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ZLSwipeableViewSwift"
-  s.version      = "0.0.8"
+  s.version      = "0.0.9"
   s.summary      = "A simple view for building card like interface like Tinder and Potluck."
   s.description  = <<-DESC
                   ZLSwipeableViewSwift is a simple view for building card like interface like Tinder and Potluck.
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/zhxnlai/ZLSwipeableViewSwift.git", :tag => "0.0.8" }
+  s.source       = { :git => "https://github.com/zhxnlai/ZLSwipeableViewSwift.git", :tag => "0.0.9" }
   s.source_files  = "ZLSwipeableViewSwift/*.swift"
 
   s.framework  = "UIKit"


### PR DESCRIPTION
Hey! Seems like podspec is not pointing to correct tag, this PR fixes that.
After merging this, make sure to push the podspec to Cocoapods by doing (while standing on `master`):

```
$ pod trunk push ZLSwipeableViewSwift.podspec
```

Merging this and pushing the spec should close the following issues: #142 and #132 